### PR TITLE
Speed improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in waterfoul.gemspec
 gemspec
+
+gem 'stackprof'

--- a/lib/waterfoul/boot_rom.rb
+++ b/lib/waterfoul/boot_rom.rb
@@ -49,10 +49,19 @@ module Waterfoul
       0x3E, 0x01, 0xE0, 0x50
     ].freeze
 
+    attr_reader :cartridge
+
+    def initialize(cartridge)
+      @cartridge = cartridge
+    end
 
     # Read bootstrap instruction given an index (memory location)
-    def self.[](i)
-      ROM[i]
+    def [](i)
+      ROM[i] || @cartridge[i]
+    end
+
+    def []=(i, v)
+      @cartridge[i] = v
     end
   end
 end

--- a/lib/waterfoul/cartridge.rb
+++ b/lib/waterfoul/cartridge.rb
@@ -16,29 +16,26 @@ module Waterfoul
   # ninetndo logo, game title, manufacturer, rom size, ram size and more.
   #
   class Cartridge
-    extend Forwardable
     # location byte in memory (physically located on cartrdige) that declares the type of cartrdige
     CARTRIDGE_TYPE_MEM_LOC = 0x147
-    # delegate any reads/writes to the memory bank controller
-    def_delegators :@mbc, :[], :[]=
 
-    def initialize(rom)
+    def self.new(rom)
       # get cartridge type byte from game program
       cartridge_type = rom[CARTRIDGE_TYPE_MEM_LOC]
-      # assign memory bank controller to cartridge
-      @mbc = cartrdige_controller cartridge_type, rom
+      # return memory bank controller to cartridge
+      cartrdige_controller cartridge_type, rom
     end
 
     private
 
     # initialize the memory bank controller given the game program and the controller type
-    def cartrdige_controller type, rom
+    def self.cartrdige_controller type, rom
       controller_const(type).new rom
     end
 
     # return the class constant that implements the behavior of the memory bank controller
     # declared by the game cartridge
-    def controller_const(type_byte)
+    def self.controller_const(type_byte)
       case type_byte
       when 0x00, 0x8, 0x9
         MBC::ROM

--- a/lib/waterfoul/cartridge.rb
+++ b/lib/waterfoul/cartridge.rb
@@ -54,5 +54,9 @@ module Waterfoul
         MBC::MBC5
       end
     end
+
+    def self.empty
+      Array.new(0x8000, 0)
+    end
   end
 end

--- a/lib/waterfoul/cli.rb
+++ b/lib/waterfoul/cli.rb
@@ -1,11 +1,25 @@
 require "thor"
+
 module Waterfoul
   class CLI < Thor
     desc 'start ROM', 'start the emulator'
     option :skip_boot
+    option :stackprof, :type => :boolean
     def start(rom_file)
       emu = Waterfoul::Emulator.new rom_file, options
-      emu.run
+
+      if options.has_key?('stackprof')
+        require 'stackprof'
+        StackProf.start(mode: :cpu)
+        begin
+          emu.run
+        ensure
+          StackProf.stop
+          StackProf.results('stackprof.dump')
+        end
+      else
+        emu.run
+      end
     end
   end
 end

--- a/lib/waterfoul/cpu.rb
+++ b/lib/waterfoul/cpu.rb
@@ -78,7 +78,7 @@ module Waterfoul
     end
 
     def check_halt
-      @halt = false if @pre_halt_interrupt != $mmu.read_byte(0xFF0F)
+      @halt = false if @pre_halt_interrupt != $mmu.read_memory_byte(0xFF0F)
     end
 
     def halted?

--- a/lib/waterfoul/cpu.rb
+++ b/lib/waterfoul/cpu.rb
@@ -125,7 +125,7 @@ module Waterfoul
       # master disable interrupts
       @ime = false
       push_onto_stack @pc
-      if_reg = $mmu.read_byte 0xFF0F
+      if_reg = $mmu.read_memory_byte 0xFF0F
       case interrupt
       when Interrupt::INTERRUPT_VBLANK
         @pc = 0x40

--- a/lib/waterfoul/emulator.rb
+++ b/lib/waterfoul/emulator.rb
@@ -6,8 +6,8 @@ module Waterfoul
       # read the given file as binary and break it down into an array of bytes
       rom = File.binread(rom_filename).bytes
       # initialize emulated CPU, GPU & Scren components
-      $mmu = MMU.new
       @cartridge = Cartridge.new rom
+      $mmu = MMU.new(@cartridge)
       @cpu = CPU.new
       @cpu = SkipBoot.set_state(@cpu) if options.has_key?('skip_boot')
       @ppu = PPU.new
@@ -15,7 +15,6 @@ module Waterfoul
     end
 
     def run
-      $mmu.cartridge = @cartridge
       loop do
         @cpu.step
         @ppu.step @cpu.m

--- a/lib/waterfoul/instructions/misc.rb
+++ b/lib/waterfoul/instructions/misc.rb
@@ -19,7 +19,7 @@ module Waterfoul
       # Halt CPU & LCD display until button pressed.
       # @flags - - - -
       def halt
-        @pre_halt_interrupt = $mmu.read_byte(0xFF0F)
+        @pre_halt_interrupt = $mmu.read_memory_byte(0xFF0F)
         @halt = true
       end
 

--- a/lib/waterfoul/interrupt.rb
+++ b/lib/waterfoul/interrupt.rb
@@ -14,13 +14,13 @@ module Waterfoul
 
     #
     def self.request_interrupt(interrupt)
-      if_reg = $mmu.read_byte IF_REG_MEM_LOC
+      if_reg = $mmu.read_memory_byte IF_REG_MEM_LOC
       $mmu.write_byte IF_REG_MEM_LOC, (if_reg | interrupt)
     end
 
     def self.pending_interrupt
-      ie_reg = $mmu.read_byte IE_REG_MEM_LOC
-      if_reg = $mmu.read_byte IF_REG_MEM_LOC
+      ie_reg = $mmu.read_memory_byte IE_REG_MEM_LOC
+      if_reg = $mmu.read_memory_byte IF_REG_MEM_LOC
       pending_interrupts = if_reg & ie_reg
 
       if pending_interrupts & INTERRUPT_VBLANK == INTERRUPT_VBLANK

--- a/lib/waterfoul/io/lcd_control.rb
+++ b/lib/waterfoul/io/lcd_control.rb
@@ -44,7 +44,7 @@ module Waterfoul
         private
 
         def lcdc
-          $mmu.read_byte LCDC_MEM_LOC
+          $mmu.read_memory_byte LCDC_MEM_LOC
         end
       end
     end

--- a/lib/waterfoul/io/lcd_control.rb
+++ b/lib/waterfoul/io/lcd_control.rb
@@ -16,7 +16,7 @@ module Waterfoul
 
         # window show/hide
         def window_enabled?
-          lcdc & 0x20 == 0x20 ? true : false
+          lcdc & 0x20 == 0x20
         end
 
         # BG Window map tile data
@@ -34,11 +34,11 @@ module Waterfoul
         end
 
         def obj_display
-          lcdc & 0x2 == 0x2 ? true : false
+          lcdc & 0x2 == 0x2
         end
 
         def bg_display
-          lcdc & 0x1 == 0x1 ? true : false
+          lcdc & 0x1 == 0x1
         end
 
         private

--- a/lib/waterfoul/mmu.rb
+++ b/lib/waterfoul/mmu.rb
@@ -11,8 +11,6 @@ module Waterfoul
     MEMORY_SIZE = 65536 # bytes
     # unmap boot rom register address
     UNMAP_BOOT_ROM_MEM_LOC = 0xFF50
-    # location in memory where the boot rom ends
-    BOOT_ROM_END_MEM_LOC = 0xFF
     # DMA register function address
     DMA_TRANSFER_MEM_LOC = 0xFF46
     # DIV register memory location
@@ -21,10 +19,9 @@ module Waterfoul
     attr_reader :memory
     attr_accessor :cartridge
 
-    def initialize
-      @cartridge = Array.new 0x8000, 0
+    def initialize(cartridge = Cartridge.empty)
       # map the boot rom when the device starts
-      @map_boot_rom = true
+      @cartridge = BootROM.new(cartridge)
       # storage for usable memory (zero filled)
       @memory = Array.new MEMORY_SIZE, 0
     end
@@ -37,12 +34,7 @@ module Waterfoul
       when 0xFF00
         Input.read_keyboard @memory[i]
       when 0x0000...0x8000 # ROM Bank 0 + n
-        # if the boot rom is enabled and the address is < 0x100
-        if @map_boot_rom && i <= BOOT_ROM_END_MEM_LOC
-          BootROM[i]
-        else
-          @cartridge[i]
-        end
+        @cartridge[i]
       when 0x8000...0xA000 # Video RAM
         @memory[i]
       when 0xA000...0xC000 # RAM Bank
@@ -65,7 +57,9 @@ module Waterfoul
       unless options[:hardware_operation]
         case i
         when UNMAP_BOOT_ROM_MEM_LOC # unmap the boot rom when 0xFF50 is wrtiten to in memory
-          @map_boot_rom = false if v == 0x1 && @map_boot_rom
+          if v == 0x1 && @cartridge.is_a?(BootROM)
+            @cartridge = @cartridge.cartridge
+          end
         when 0xFF00
           @memory[i] = v | 0xF
         when 0xFF46 # DMA transfer

--- a/lib/waterfoul/mmu.rb
+++ b/lib/waterfoul/mmu.rb
@@ -17,7 +17,6 @@ module Waterfoul
     DIV_MEM_LOC = 0xFF04
 
     attr_reader :memory
-    attr_accessor :cartridge
 
     def initialize(cartridge = Cartridge.empty)
       # map the boot rom when the device starts

--- a/lib/waterfoul/mmu.rb
+++ b/lib/waterfoul/mmu.rb
@@ -81,6 +81,10 @@ module Waterfoul
     alias_method :write_byte, :[]=
     alias_method :read_byte, :[]
 
+    def read_memory_byte(i)
+      @memory[i]
+    end
+
     # read 2 bytes from memory
     def read_word(addr)
       self[addr] | (self[addr + 1] << 8)

--- a/lib/waterfoul/mmu.rb
+++ b/lib/waterfoul/mmu.rb
@@ -30,21 +30,14 @@ module Waterfoul
     def [](i)
       raise MemoryOutOfBounds if i > MEMORY_SIZE || i < 0
 
-      case i
-      when 0xFF00
+      if i == 0xFF00
         Input.read_keyboard @memory[i]
-      when 0x0000...0x8000 # ROM Bank 0 + n
-        @cartridge[i]
-      when 0x8000...0xA000 # Video RAM
+      elsif (0x8000...0xA000) === i or (0xC000...0xE000) === i or (0xFE00..0xFFFF) === i
         @memory[i]
-      when 0xA000...0xC000 # RAM Bank
-        @cartridge[i]
-      when 0xC000...0xE000 # Internal RAM
-        @memory[i]
-      when 0xE000...0xFE00 # Internal RAM (shadow)
+      elsif (0xE000...0xFE00) === i
         @memory[i - 0x2000]
-      when 0xFE00..0xFFFF # Graphics (OAM), IO, Zero-page
-        @memory[i]
+      elsif (0x0000...0x8000) === i or (0xA000...0xC000) === i
+        @cartridge[i]
       end
     end
 

--- a/lib/waterfoul/mmu.rb
+++ b/lib/waterfoul/mmu.rb
@@ -32,12 +32,12 @@ module Waterfoul
 
       if i == 0xFF00
         Input.read_keyboard @memory[i]
-      elsif (0x8000...0xA000) === i or (0xC000...0xE000) === i or (0xFE00..0xFFFF) === i
+      elsif i >= 0x8000 && i < 0xA000 or i >= 0xC000 && i < 0xE000 or i >= 0xFE00
         @memory[i]
-      elsif (0xE000...0xFE00) === i
-        @memory[i - 0x2000]
-      elsif (0x0000...0x8000) === i or (0xA000...0xC000) === i
+      elsif i < 0x8000 or i >= 0xA000 && i < 0xC000
         @cartridge[i]
+      else # if (0xE000...0xFE00) === i
+        @memory[i - 0x2000]
       end
     end
 

--- a/lib/waterfoul/ppu.rb
+++ b/lib/waterfoul/ppu.rb
@@ -128,7 +128,7 @@ module Waterfoul
     end
 
     def update_stat_mode
-      stat = $mmu.read_byte 0xFF41
+      stat = $mmu.read_memory_byte 0xFF41
       new_stat = (stat & 0xFC) | (@mode & 0x3)
       $mmu.write_byte 0xFF41, new_stat
     end
@@ -140,8 +140,8 @@ module Waterfoul
       # if the LCDC window enable bit flag is not set
       return if @window_line > 143 || !IO::LCDControl.window_enabled?
 
-      window_pos_x = $mmu.read_byte(0xFF4B) - 7
-      window_pos_y = $mmu.read_byte(0xFF4A)
+      window_pos_x = $mmu.read_memory_byte(0xFF4B) - 7
+      window_pos_y = $mmu.read_memory_byte(0xFF4A)
 
       # don't render if the window is outside the bounds of the screen
       return if window_pos_x > 159 || window_pos_y > 143 || window_pos_y > line
@@ -206,14 +206,14 @@ module Waterfoul
       39.downto(0) do |sprite|
         sprite_offset = sprite * 4
 
-        sprite_y = $mmu.read_byte(0xFE00 + sprite_offset) - 16
+        sprite_y = $mmu.read_memory_byte(0xFE00 + sprite_offset) - 16
         next if sprite_y > line || (sprite_y + sprite_size) <= line
 
-        sprite_x = $mmu.read_byte(0xFE00 + sprite_offset + 1) - 8
+        sprite_x = $mmu.read_memory_byte(0xFE00 + sprite_offset + 1) - 8
         next if sprite_x < -7 || sprite_x >= Screen::SCREEN_WIDTH
 
-        sprite_tile_offset = ($mmu.read_byte(0xFE00 + sprite_offset + 2) & (sprite_size == 16 ? 0xFE : 0xFF)) * 16
-        sprite_flags = $mmu.read_byte(0xFE00 + sprite_offset + 3)
+        sprite_tile_offset = ($mmu.read_memory_byte(0xFE00 + sprite_offset + 2) & (sprite_size == 16 ? 0xFE : 0xFF)) * 16
+        sprite_flags = $mmu.read_memory_byte(0xFE00 + sprite_offset + 3)
         x_flip = sprite_flags & 0x20 == 0x20 ? true : false
         y_flip = sprite_flags & 0x40 == 0x40 ? true : false
         #above_bg = sprite_flags & 0x80 == 0x80 ? true : false
@@ -269,9 +269,9 @@ module Waterfoul
         tiles_select = IO::LCDControl.bg_tile_select
         map_select = IO::LCDControl.bg_map_select
         # x pixel offset
-        scx = $mmu.read_byte 0xFF43
+        scx = $mmu.read_memory_byte 0xFF43
         # y pixel offset
-        scy = $mmu.read_byte 0xFF42
+        scy = $mmu.read_memory_byte 0xFF42
         # line with y offset
         line_adjusted = (line + scy) & 0xFF
         # get position of tile row to read
@@ -332,8 +332,8 @@ module Waterfoul
 
     def compare_lylc
       if IO::LCDControl.screen_enabled?
-        lyc = $mmu.read_byte 0xFF45
-        stat = $mmu.read_byte 0xFF41
+        lyc = $mmu.read_memory_byte 0xFF45
+        stat = $mmu.read_memory_byte 0xFF41
 
         if lyc == current_line
           stat = stat | 0x4
@@ -345,7 +345,7 @@ module Waterfoul
     end
 
     def current_line
-      $mmu.read_byte LCDC_Y_COORDINATE_MEM_LOC
+      $mmu.read_memory_byte LCDC_Y_COORDINATE_MEM_LOC
     end
 
     def reset_current_line

--- a/lib/waterfoul/ppu.rb
+++ b/lib/waterfoul/ppu.rb
@@ -37,19 +37,19 @@ module Waterfoul
       @modeclock += cycles
       @auxillary_modeclock += cycles
 
-      if IO::LCDControl.screen_enabled? && @screen_enabled
-        case @mode
-        when H_BLANK_STATE
-          hblank if @modeclock >= H_BLANK_TIME
-        when V_BLANK_STATE
-          vblank
-        when OAM_READ_STATE
-          oam if @modeclock >= OAM_SCANLINE_TIME
-        when VMRAM_READ_STATE
-          vram if @modeclock >= VRAM_SCANLINE_TIME
-        end
-      else
-        if IO::LCDControl.screen_enabled?
+      if IO::LCDControl.screen_enabled?
+        if @screen_enabled
+          case @mode
+          when H_BLANK_STATE
+            hblank if @modeclock >= H_BLANK_TIME
+          when V_BLANK_STATE
+            vblank
+          when OAM_READ_STATE
+            oam if @modeclock >= OAM_SCANLINE_TIME
+          when VMRAM_READ_STATE
+            vram if @modeclock >= VRAM_SCANLINE_TIME
+          end
+        else
           @screen_enabled = true
           @modeclock = 0
           @mode = 0
@@ -58,9 +58,9 @@ module Waterfoul
           reset_current_line
           update_stat_mode
           compare_lylc
-        else
-          @screen_enabled = false
         end
+      else
+        @screen_enabled = false
       end
     end
 

--- a/lib/waterfoul/ppu.rb
+++ b/lib/waterfoul/ppu.rb
@@ -281,7 +281,8 @@ module Waterfoul
         # relative line number offset
         tile_line_offset = tile_line * 2
         palette = $mmu.read_memory_byte 0xFF47
-        0.upto(31) do |x|
+        x = 0
+        while x < 32
           tile = 0
           if tiles_select == 0x8800
             tile = signed_value $mmu.read_byte(map_select + y_offset + x)
@@ -297,18 +298,20 @@ module Waterfoul
           byte_1 = $mmu.read_byte tile_address
           byte_2 = $mmu.read_byte (tile_address + 1)
 
-          0.upto(7) do |pixelx|
-            buffer_addr = line_pixel_offset + pixelx - scx
-
-            next if buffer_addr >= Screen::SCREEN_WIDTH
-
-            pixel = (byte_1 & (0x1 << (7 - pixelx)) > 0) ? 1 : 0
-            pixel |= (byte_2 & (0x1 << (7 - pixelx)) > 0) ? 2 : 0
+          pixelx = 0
+          buffer_addr = line_pixel_offset - scx
+          while pixelx < 8 and buffer_addr < Screen::SCREEN_WIDTH
+            shift = 0x1 << (7 - pixelx)
+            pixel = (byte_1 & shift > 0) ? 1 : 0
+            pixel |= (byte_2 & shift > 0) ? 2 : 0
             position = line_width + buffer_addr
             color = (palette >> (pixel * 2)) & 0x3
 
             @framebuffer[position] = rgb(color)
+            pixelx += 1
+            buffer_addr = line_pixel_offset + pixelx - scx
           end
+          x += 1
         end
       else
         0.upto(Screen::SCREEN_WIDTH - 1) do |i|

--- a/lib/waterfoul/ppu.rb
+++ b/lib/waterfoul/ppu.rb
@@ -304,7 +304,7 @@ module Waterfoul
             pixel = (byte_1 & (0x1 << (7 - pixelx)) > 0) ? 1 : 0
             pixel |= (byte_2 & (0x1 << (7 - pixelx)) > 0) ? 2 : 0
             position = line_width + buffer_addr
-            palette = $mmu.read_byte 0xFF47
+            palette = $mmu.read_memory_byte 0xFF47
             color = (palette >> (pixel * 2)) & 0x3
 
             @framebuffer[position] = rgb(color)

--- a/lib/waterfoul/ppu.rb
+++ b/lib/waterfoul/ppu.rb
@@ -280,6 +280,7 @@ module Waterfoul
         tile_line = line_adjusted % 8
         # relative line number offset
         tile_line_offset = tile_line * 2
+        palette = $mmu.read_memory_byte 0xFF47
         0.upto(31) do |x|
           tile = 0
           if tiles_select == 0x8800
@@ -304,7 +305,6 @@ module Waterfoul
             pixel = (byte_1 & (0x1 << (7 - pixelx)) > 0) ? 1 : 0
             pixel |= (byte_2 & (0x1 << (7 - pixelx)) > 0) ? 2 : 0
             position = line_width + buffer_addr
-            palette = $mmu.read_memory_byte 0xFF47
             color = (palette >> (pixel * 2)) & 0x3
 
             @framebuffer[position] = rgb(color)

--- a/lib/waterfoul/screen.rb
+++ b/lib/waterfoul/screen.rb
@@ -14,6 +14,7 @@ module Waterfoul
       SDL.SetHint "SDL_HINT_RENDER_SCALE_QUALITY",  "2"
       SDL.RenderSetLogicalSize(@renderer, WINDOW_WIDTH, WINDOW_HEIGHT)
       @texture = SDL.CreateTexture @renderer, SDL::PIXELFORMAT_ARGB8888, 1, SCREEN_WIDTH, SCREEN_HEIGHT
+      @last = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
 
     def render(framebuffer)
@@ -22,6 +23,13 @@ module Waterfoul
       SDL.RenderClear @renderer
       SDL.RenderCopy @renderer, @texture, nil, nil
       SDL.RenderPresent @renderer
+
+      t = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      fps = 1.0 / (t - @last)
+      fps = fps.floor.to_s
+      @last = t
+
+      SDL.SetWindowTitle(@window, "waterfoul (#{fps} fps)")
     end
   end
 end

--- a/lib/waterfoul/sdl.rb
+++ b/lib/waterfoul/sdl.rb
@@ -36,5 +36,6 @@ module Waterfoul
     attach_function :GetKeyboardState, 'SDL_GetKeyboardState', [:pointer], :pointer
     attach_function :SetHint, 'SDL_SetHint', [:string, :string], :int
     attach_function :RenderSetLogicalSize, 'SDL_RenderSetLogicalSize', [:pointer, :int, :int], :int
+    attach_function :SetWindowTitle, 'SDL_SetWindowTitle', [:pointer, :string], :void
   end
 end

--- a/lib/waterfoul/timer.rb
+++ b/lib/waterfoul/timer.rb
@@ -27,9 +27,9 @@ module Waterfoul
     end
 
     def inc_tima_register
-      tima = $mmu.read_byte 0xFF05
+      tima = $mmu.read_memory_byte 0xFF05
       if tima == 0xFF
-        tima = $mmu.read_byte 0xFF06
+        tima = $mmu.read_memory_byte 0xFF06
         Interrupt.request_interrupt(Interrupt::INTERRUPT_TIMER)
       else
         tima += 1
@@ -39,7 +39,7 @@ module Waterfoul
     end
 
     def inc_div_register
-      div = $mmu.read_byte 0xFF04
+      div = $mmu.read_memory_byte 0xFF04
       div = (div + 1) & 0xFF
       $mmu.write_byte 0xFF04, div, hardware_operation: true
       @div_cycles -= DIV_INC_TIME
@@ -52,7 +52,7 @@ module Waterfoul
     end
 
     def update
-      @register = $mmu.read_byte 0xFF07
+      @register = $mmu.read_memory_byte 0xFF07
     end
 
     def running?


### PR DESCRIPTION
This PR improves the speed of the emulator on Tetris from 8 FPS to 30 FPS (still some way to go for 60).

I used [stackprof](https://github.com/tmm1/stackprof) to identity the hotspots.
The sample profiler is now enabled by passing `--stackprof` to `exe/waterfoul start`.

The emulator now also displays the FPS in the window title.

The initial stackprof report was:
```
==================================
  Mode: cpu(1000)
  Samples: 119330 (0.01% miss rate)
  GC: 3109 (2.61%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
     90270  (75.6%)       84166  (70.5%)     Waterfoul::MMU#[]
    129160 (108.2%)        7744   (6.5%)     Waterfoul::PPU#render_bg
      3912   (3.3%)        3912   (3.3%)     Waterfoul::Cartridge#[]
      2911   (2.4%)        2911   (2.4%)     Waterfoul::PPU#rgb
      1736   (1.5%)        1736   (1.5%)     Waterfoul::MBC::ROM#[]
      1850   (1.6%)        1584   (1.3%)     Waterfoul::MMU#[]=
     14277  (12.0%)        1474   (1.2%)     Waterfoul::Interrupt.pending_interrupt
      1177   (1.0%)        1177   (1.0%)     Waterfoul::CPU#reset_tick
```
So `MMU#[]` was clearly the bottleneck.

After these commits it looks like:
```
==================================
  Mode: cpu(1000)
  Samples: 35996 (0.01% miss rate)
  GC: 386 (1.07%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      5177  (14.4%)        5177  (14.4%)     Waterfoul::MMU#read_memory_byte
      7575  (21.0%)        4854  (13.5%)     Waterfoul::MMU#[]
      9465  (26.3%)        4307  (12.0%)     Waterfoul::PPU#render_bg
      3172   (8.8%)        3172   (8.8%)     Waterfoul::PPU#rgb
      2627   (7.3%)        2627   (7.3%)     Waterfoul::MBC::ROM#[]
      3166   (8.8%)        1770   (4.9%)     Waterfoul::Interrupt.pending_interrupt
      1830   (5.1%)        1598   (4.4%)     Waterfoul::MMU#[]=
      1121   (3.1%)        1121   (3.1%)     Waterfoul::CPU#reset_tick
     15416  (42.8%)        1112   (3.1%)     Waterfoul::PPU#step
       838   (2.3%)         838   (2.3%)     Waterfoul::CPU#instruction_cycle_time
      2379   (6.6%)         823   (2.3%)     Waterfoul::Timer#tick
      8400  (23.3%)         821   (2.3%)     Waterfoul::CPU#perform_instruction
       743   (2.1%)         743   (2.1%)     Waterfoul::Instructions::Registers#set_z_flag
       732   (2.0%)         732   (2.0%)     Waterfoul::Instructions::Registers#reset_flags
```
It is less clear, but `PPU#render_bg` seems fairly slow compared to the rest.
Maybe some higher-level optimization could be done such as pre-computing a recurring pattern once, or if the background is a uniform color that might be easy to detect.