### PR TITLE
Initialize CPU instance variables

### DIFF
--- a/lib/waterfoul/cpu.rb
+++ b/lib/waterfoul/cpu.rb
@@ -43,7 +43,7 @@ module Waterfoul
     include Instructions::Prefix
 
     # 8 bit registers
-    attr_reader :a, :b, :c, :d, :e, :f, :h, :l, :f
+    attr_reader :a, :b, :c, :d, :e, :f, :h, :l
     # CPU instruction cycle count
     attr_reader :m
     # 16 bit registers
@@ -55,7 +55,7 @@ module Waterfoul
     def initialize(options = {})
       @pc = 0x0000
       @sp = 0x0000
-      @a = @b = @c = @d = @e = @f = @h = @l = @f = 0x00
+      @a = @b = @c = @d = @e = @f = @h = @l = 0x00
       @m = 0
       @timer = Timer.new
       @ime = false

--- a/lib/waterfoul/cpu.rb
+++ b/lib/waterfoul/cpu.rb
@@ -56,9 +56,10 @@ module Waterfoul
       @pc = 0x0000
       @sp = 0x0000
       @a = @b = @c = @d = @e = @f = @h = @l = 0x00
-      @m = 0
       @timer = Timer.new
       @ime = false
+      @halt = false
+      reset_tick
     end
 
     # This method emulates the CPU cycle process. Each instruction is


### PR DESCRIPTION
This fixes a few `warning: instance variable @halt not initialized` warnings (seen when running with `-w`).

It also boosts performance significantly for TruffleRuby, because the set of instance variables is now stable in that class (instead of having many different variants).

With this, I get ~375FPS on Tetris with TruffleRuby `master` running in `--jvm` mode!
(`truffleruby 20.2.0-dev-a9555582, like ruby 2.6.5, GraalVM CE JVM [x86_64-linux]`)
![Screenshot from 2020-05-10 14-35-53](https://user-images.githubusercontent.com/168854/81499446-11552d80-92cc-11ea-80ea-02103a32dbab.png)
For comparison, on my machine Tetris on MRI 2.6.6 is ~50FPS, and ~77FPS with `--jit`.
On MRI 2.7.1 it's ~55FPS, and ~95FPS with `--jit`.