### PR TITLE
Move development dependencies to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,13 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in waterfoul.gemspec
 gemspec
 
-gem 'stackprof'
+group :development do
+  gem "rake", "~> 13.0"
+  gem "rspec"
+  gem "guard"
+  gem "guard-rspec"
+
+  gem 'byebug', platforms: :mri
+  gem 'stackprof', platforms: :mri
+end

--- a/waterfoul.gemspec
+++ b/waterfoul.gemspec
@@ -26,13 +26,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.1"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "byebug"
-  spec.add_development_dependency "guard"
-  spec.add_development_dependency "guard-rspec"
-
   spec.add_dependency "thor"
   spec.add_dependency "ffi", "~> 1.12.2"
 end


### PR DESCRIPTION
* Which allows filtering by platforms, etc.